### PR TITLE
Fix the bug in 'confluence_version' fact:

### DIFF
--- a/lib/facter/confluence_version.rb
+++ b/lib/facter/confluence_version.rb
@@ -4,9 +4,14 @@
 
 Facter.add(:confluence_version) do
   setcode do
-    # Get me all the processes and split into a bunch of tokens
-    procs = %x{ps ax}.split("\n")
-    # Select the confluence one, split the resulting string and extract version number
-    procs.detect{ |x| x.include?('atlassian-confluence') }.split(/[- \/]/).detect{ |x| x =~ /^(\d+\.){1,2}\d*$/ }
+    # Get a list of processes and look for the confluence one.
+    conf_proc = %x{ps ax}.split("\n").detect{ |x| x.include?('atlassian-confluence') }
+    if conf_proc.nil?
+      # Make sure the fact is set to a something even if the list is nil.
+      "unknown"
+    else
+      # Get version from a running process.
+      conf_proc.split(/[- \/]/).detect{ |x| x =~ /^(\d+\.){1,2}\d*$/ }
+    end
   end
 end


### PR DESCRIPTION
This commit makes sure that the 'confluence_version' fact
is set to something even if Confluence is not on the list of
processes.
The "unknown" value is used in a conditional in the `init.pp`
manifest.